### PR TITLE
send counter even when increment is zero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = graphiter
 PROJECT_DESCRIPTION = Graphite (carbon) metrics reporter for Erlang
-PROJECT_VERSION = 1.0.3
+PROJECT_VERSION = 1.0.4
 
 DEPS = supervisor3
 

--- a/src/graphiter.app.src
+++ b/src/graphiter.app.src
@@ -1,6 +1,6 @@
 {application, graphiter, [
   {description, "Graphite (carbon) metrics reporter for Erlang"},
-  {vsn, "1.0.3"},
+  {vsn, "1.0.4"},
   {registered, []},
   {applications, [
     kernel,

--- a/src/graphiter.erl
+++ b/src/graphiter.erl
@@ -61,7 +61,6 @@ cast(Name, Path, Value, Epoch) ->
 
 %% @doc Increment a counter and send to graphite.
 -spec incr_cast(name(), path(), value()) -> ok.
-incr_cast(_Name, _Path, 0) -> ok;
 incr_cast(Name, Path0, IncrValue) when is_integer(IncrValue) ->
   Path = path(Path0),
   Default = {Path, 0},


### PR DESCRIPTION
to avoid `null` data points in graphite.