### PR TITLE
Remove predefined APPLICATION macro in erlc opts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = graphiter
 PROJECT_DESCRIPTION = Graphite (carbon) metrics reporter for Erlang
-PROJECT_VERSION = 1.0.5
+PROJECT_VERSION = 1.0.6
 
 DEPS = supervisor3
 
@@ -8,9 +8,7 @@ dep_supervisor3 = hex 1.1.5
 
 include erlang.mk
 
-MORE_ERLC_OPTS = -DAPPLICATION=graphiter
-ERLC_OPTS += $(MORE_ERLC_OPTS)
-
+.PHONY: vsn-check
 vsn-check:
 	./vsn-check.sh $(PROJECT_VERSION)
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts,[ debug_info
           , warnings_as_errors
-          , {d,{'APPLICATION', graphiter}}
           ]}.
 
 {deps,[ {supervisor3, "1.1.5"} ]}.

--- a/src/graphiter.app.src
+++ b/src/graphiter.app.src
@@ -1,6 +1,6 @@
 {application, graphiter, [
   {description, "Graphite (carbon) metrics reporter for Erlang"},
-  {vsn, "1.0.5"},
+  {vsn, "1.0.6"},
   {registered, []},
   {applications, [
     kernel,

--- a/src/graphiter.erl
+++ b/src/graphiter.erl
@@ -6,6 +6,7 @@
         , cast/4
         , incr_cast/3
         , path/1
+        , get_writers/0
         ]).
 
 -export_type([ name/0
@@ -20,7 +21,16 @@
 -type value() :: number().
 -type epoch() :: pos_integer().
 
+-ifndef(APPLICATION).
+-define(APPLICATION, ?MODULE).
+-endif.
+
 %%%_* APIs =====================================================================
+
+%% @doc Get configured writers.
+-spec get_writers() -> [{name(), proplists:proplist()}].
+get_writers() ->
+  application:get_env(?APPLICATION, writers, []).
 
 %% @doc Start a new metrics writer under graphite_erlang's supervisor.
 %% Supported options:

--- a/src/graphiter_app.erl
+++ b/src/graphiter_app.erl
@@ -9,3 +9,9 @@ start(_Type, _Args) ->
 
 stop(_State) ->
   ok.
+
+%%%_* Emacs ====================================================================
+%%% Local Variables:
+%%% allout-layout: t
+%%% erlang-indent-level: 2
+%%% End:

--- a/src/graphiter_sup.erl
+++ b/src/graphiter_sup.erl
@@ -21,7 +21,7 @@ init([]) ->
 
 writers() ->
   %% start writers pre-defined in app env
-  Writers = application:get_env(?APPLICATION, writers, []),
+  Writers = graphiter:get_writers(),
   lists:map(fun writer/1, Writers).
 
 writer({Name, Opts}) ->


### PR DESCRIPTION
It becomes a problem when the dependency chain is:
erlang.mk -> rebar(3) -> THIS.

When erlang.mk auto-patch rebar(3) project (and all its deeper level dependencies)
the erlc options in rebar.config is concatenated as erlc command options

e.g.
`erlc -v +debug_info +'{parse_transform, lager_transform}' -DAPPLICATION=graphiter -DAPPLICATION=graphiter ......`

which in turn causes 'macro redefined' error.
